### PR TITLE
Updated from verions 1.3.1-SNAPSHOT to 1.3.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>net.jakubholy.testing</groupId>
 	<artifactId>dbunit-express</artifactId>
 	<name>Express DbUnit with Embedded Derby DB</name>
-	<version>1.3.1-SNAPSHOT</version>
+	<version>1.3.2-SNAPSHOT</version>
 
 	<dependencies>
 
@@ -18,7 +18,7 @@
 			<!-- Issue mvn dependency:sources to download also its sources. -->
 			<groupId>org.dbunit</groupId>
 			<artifactId>dbunit</artifactId>
-			<version>2.4.8</version>
+			<version>2.4.9</version>
 			<type>jar</type>
 			<exclusions>
 				<exclusion>
@@ -40,13 +40,13 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.5.6</version>
+			<version>1.7.3</version>
 		</dependency>
 		<dependency>
             
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.5.6</version>
+			<version>1.7.3</version>
 			<!--exclusions for slf4j-log4j12>
 				<exclusion>
 				  <groupId>com.sun.jmx</groupId>

--- a/src/main/java/net/jakubholy/dbunitexpress/DatabaseCreator.java
+++ b/src/main/java/net/jakubholy/dbunitexpress/DatabaseCreator.java
@@ -115,7 +115,7 @@ public class DatabaseCreator {
     /**
      * Execute the ddlStatements on the connection.
      * @param connection (required) connection to the target database.
-     * @param ddlStatements (required) DDL statements separated by semi-colon (';').
+     * @param ddlStatements (required) DDL statements separated by hash ('#').
      * It shouldn't contain any -- comments as JDBC may not be able to ignore them as appropriate.
      * @throws SQLException
      */
@@ -124,7 +124,7 @@ public class DatabaseCreator {
 
 		final java.sql.Statement ddlStmt = connection.createStatement();
 		try {
-	        final String[] statements = ddlStatements.split(";");
+	        final String[] statements = ddlStatements.split("#");
 
 	        for (int i = 0; i < statements.length; i++) {
 	        	if (statements[i].trim().length() > 0) {

--- a/src/test/resources/DatabaseCreatorTest-additional2.ddl
+++ b/src/test/resources/DatabaseCreatorTest-additional2.ddl
@@ -2,4 +2,5 @@
 --
 -- Using the default schema
 create table new_custom_table2 (
-	my_column varchar(225));
+	my_column varchar(225))
+#

--- a/src/test/resources/DatabaseCreatorTest.ddl
+++ b/src/test/resources/DatabaseCreatorTest.ddl
@@ -2,4 +2,5 @@
 --
 -- Using the default schema
 create table new_custom_table (
-	my_column varchar(225));
+	my_column varchar(225))
+#

--- a/testData/create_db_content.ddl
+++ b/testData/create_db_content.ddl
@@ -3,8 +3,9 @@
 -- see net.jakubholy.testing.dbunit.DatabaseCreator#main.
 
 -- Replace the text below with whatever you need.
-create schema my_test_schema;
-
+create schema my_test_schema
+#
 create table my_test_schema.my_test_table (
 	id int primary key
-	, some_text varchar(225));
+	, some_text varchar(225))
+#	


### PR DESCRIPTION
Updated to use slf4j 1.7.3

Updated to use dbunit 2.4.9

Changed sql statement delimiter from ; (semi-colon to ) to # (hash)
This will make it possible to execute a ddl file with functions.
I.e. for a postgres database....

CREATE OR REPLACE FUNCTION product_history()
  RETURNS trigger AS
$BODY$
BEGIN
INSERT INTO product_history (id, product_id, edit_ts, name, description)
    VALUES (nextval('product_history_sequence'), OLD.id, now(), OLD.name, OLD.description);
RETURN NULL;
END;
$BODY$
LANGUAGE plpgsql;
# 

CREATE TRIGGER product_update_delete
  AFTER DELETE OR UPDATE
  ON product
  FOR EACH ROW
  EXECUTE PROCEDURE product_history();
# 
